### PR TITLE
Maintenance & drop support for sphinx <4.5.0

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build package
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          pip install wheel "setuptools>=65.5.0"
           python setup.py sdist bdist_wheel
 
       - name: Publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
 
@@ -25,7 +25,7 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -40,7 +40,7 @@ jobs:
         make html
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: docs-${{ matrix.docs-dir }}-py${{ matrix.python-version }}-sph${{ matrix.sphinx-ver }}
         path: ./${{ matrix.docs-dir }}/_build/html

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        docs-dir: [doc, doc_copybutton]
         sphinx-ver: ["1.8.6", "2.4.5", "3.5.4", "4.5.0"]
+        docs-dir: ["doc", "doc_copybutton"]
         exclude:
           # py 3.10 + sphinx 3.5.4 has issues with typing
           - python-version: "3.10"

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         docs-dir: ["doc", "doc_copybutton"]
-        sphinx-ver: ["1.8.6", "2.4.5", "3.5.4", "4.5.0", "5.3.0"]
+        sphinx-ver: ["4.5.0", "5.3.0"]
         exclude:
           # py 3.10 + sphinx 3.5.4 has issues with typing
           - python-version: "3.10"

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        sphinx-ver: ["1.8.6", "2.4.5", "3.5.4", "4.5.0"]
         docs-dir: ["doc", "doc_copybutton"]
+        sphinx-ver: ["1.8.6", "2.4.5", "3.5.4", "4.5.0", "5.3.0"]
         exclude:
           # py 3.10 + sphinx 3.5.4 has issues with typing
           - python-version: "3.10"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,6 +154,14 @@ There's an example of this in the doc_copybutton folder.
 Changelog
 ================================
 
+V0.3.0 - 11-dec-2022
+-----------------------
+
+- Dropped support for sphinx < 4.5.0. This is due to https://github.com/sphinx-doc/sphinx/issues/10291
+- Added tests for sphinx 5
+- Modified sphinx dependency to be less than v6
+
+
 V0.2.0 - 14-may-2022
 -----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=[
         "jinja2<3.1",  # https://github.com/sphinx-doc/sphinx/issues/10291
-        "sphinx>=1.8,<6",
+        "sphinx>=4.5.0,<6",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     package_data={'sphinx_toggleprompt': ['_static/toggleprompt.js_t']},
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=[
-        "jinja2<3.1",  # https://github.com/sphinx-doc/sphinx/issues/10291
         "sphinx>=4.5.0,<6",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_data={'sphinx_toggleprompt': ['_static/toggleprompt.js_t']},
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=[
-        "sphinx>=1.8",
         "jinja2<3.1",  # https://github.com/sphinx-doc/sphinx/issues/10291
+        "sphinx>=1.8,<6",
     ]
 )

--- a/sphinx_toggleprompt/__init__.py
+++ b/sphinx_toggleprompt/__init__.py
@@ -2,7 +2,7 @@ from sphinx.util import logging
 from pathlib import Path
 
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
- Enforced use of recent setuptools version when building wheel/src to auto include LICENSE files - Closes #16
- Removed jinja2 version pin - Closes #17
- Dropped support for sphinx < 4.5.0. This is due to https://github.com/sphinx-doc/sphinx/issues/10291
- Added tests for sphinx 5
- Modified sphinx dependency to be less than v6
- Bumped dependencies in GHA
- Bumped package version to 0.3.0

