### PR TITLE
Allow sphinx v6 & bump version

### DIFF
--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -17,6 +17,12 @@ jobs:
           # py 3.10 + sphinx 3.5.4 has issues with typing
           - python-version: "3.10"
             sphinx-ver: "3.5.4"
+          # Sphinx v6 does not support python 3.6:
+          - python-version: "3.6"
+            sphinx-ver: "6.1.3"
+          # Sphinx v6 does not support python 3.7
+          - python-version: "3.7"
+            sphinx-ver: "6.1.3"
 
     steps:
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.10"]
         docs-dir: ["doc", "doc_copybutton"]
-        sphinx-ver: ["4.5.0", "5.3.0"]
+        sphinx-ver: ["4.5.0", "5.3.0", "6.1.3"]
         exclude:
           # py 3.10 + sphinx 3.5.4 has issues with typing
           - python-version: "3.10"

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: ["4.5.0", "5.3.0", "6.1.3"]
         exclude:

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -14,9 +14,6 @@ jobs:
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: ["4.5.0", "5.3.0", "6.1.3"]
         exclude:
-          # py 3.10 + sphinx 3.5.4 has issues with typing
-          - python-version: "3.10"
-            sphinx-ver: "3.5.4"
           # Sphinx v6 does not support python 3.6:
           - python-version: "3.6"
             sphinx-ver: "6.1.3"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,6 +154,13 @@ There's an example of this in the doc_copybutton folder.
 Changelog
 ================================
 
+V0.4.0 - 08-apr-2023
+-----------------------
+
+- Loosened max sphinx version to v6, up from v5.
+- Enabled Python 3.11 in CI tests.
+
+
 V0.3.1 - 11-dec-2022
 -----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     package_data={'sphinx_toggleprompt': ['_static/toggleprompt.js_t']},
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=[
-        "sphinx>=4.5.0,<6",
+        "sphinx>=4.5.0,<7",
     ]
 )

--- a/sphinx_toggleprompt/__init__.py
+++ b/sphinx_toggleprompt/__init__.py
@@ -2,7 +2,7 @@ from sphinx.util import logging
 from pathlib import Path
 
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
- Loosened max sphinx version to v6, up from v5.
- Enabled Python 3.11 in CI tests.