### PR TITLE
Support Sphinx 6 & 7

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 
@@ -25,7 +25,7 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,16 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: ["4.5.0", "5.3.0", "6.2.1"]
-        exclude:
-          # Sphinx v6 does not support python 3.6:
-          - python-version: "3.6"
-            sphinx-ver: "6.2.1"
-          # Sphinx v6 does not support python 3.7
-          - python-version: "3.7"
-            sphinx-ver: "6.2.1"
 
     steps:
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -12,14 +12,14 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         docs-dir: ["doc", "doc_copybutton"]
-        sphinx-ver: ["4.5.0", "5.3.0", "6.1.3"]
+        sphinx-ver: ["4.5.0", "5.3.0", "6.2.1"]
         exclude:
           # Sphinx v6 does not support python 3.6:
           - python-version: "3.6"
-            sphinx-ver: "6.1.3"
+            sphinx-ver: "6.2.1"
           # Sphinx v6 does not support python 3.7
           - python-version: "3.7"
-            sphinx-ver: "6.1.3"
+            sphinx-ver: "6.2.1"
 
     steps:
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: ["4.5.0", "5.3.0", "6.2.1"]
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -36,7 +36,7 @@ jobs:
         make html
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: docs-${{ matrix.docs-dir }}-py${{ matrix.python-version }}-sph${{ matrix.sphinx-ver }}
         path: ./${{ matrix.docs-dir }}/_build/html

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: ["4.5.0", "5.3.0", "6.2.1", "7.2.6"]
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         docs-dir: ["doc", "doc_copybutton"]
-        sphinx-ver: ["4.5.0", "5.3.0", "6.2.1"]
+        sphinx-ver: ["4.5.0", "5.3.0", "6.2.1", "7.2.6"]
 
     steps:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,6 +154,15 @@ There's an example of this in the doc_copybutton folder.
 Changelog
 ================================
 
+V0.5.0 - 07-jan-2024
+-----------------------
+
+- Updated the main javascript code to match `that from the official Python docs theme <https://github.com/python/python-docs-theme/blob/d1e6df49a042c3aae79a2a9bc384bb1587fae777/python_docs_theme/static/copybutton.js>`_.
+  This is more or less a complete rewrite, and notably no longer relies on jquery.
+- Support Sphinx 4.5.0 through 8.x (previously was 4.5.0 through 5.x).
+- Support Python 3.9 through 3.12 (previously was 3.6 through 3.11).
+
+
 V0.4.0 - 08-apr-2023
 -----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=find_packages(),
     package_data={'sphinx_toggleprompt': ['_static/toggleprompt.js_t']},
     classifiers=["License :: OSI Approved :: MIT License"],
+    python_requires=">=3.9",
     install_requires=[
         "sphinx>=4.5.0,<8",
     ]

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     package_data={'sphinx_toggleprompt': ['_static/toggleprompt.js_t']},
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=[
-        "sphinx>=4.5.0,<7",
+        "sphinx>=4.5.0,<8",
     ]
 )

--- a/sphinx_toggleprompt/_static/toggleprompt.js_t
+++ b/sphinx_toggleprompt/_static/toggleprompt.js_t
@@ -5,8 +5,9 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
 function* getHideableCopyButtonElements(rootElement) {
     // yield all elements with the "go" (Generic.Output),
-    // "gp" (Generic.Prompt), or "gt" (Generic.Traceback) CSS class
-    for (const el of rootElement.querySelectorAll('.go, .gp, .gt')) {
+    // "gp" (Generic.Prompt), "gt" (Generic.Traceback),
+    // or "gh" (ipython) CSS class
+    for (const el of rootElement.querySelectorAll('.go, .gp, .gt, .gh')) {
         yield el
     }
     // tracebacks (.gt) contain bare text elements that need to be
@@ -15,7 +16,7 @@ function* getHideableCopyButtonElements(rootElement) {
         while ((el = el.nextSibling) && el.nodeType !== Node.DOCUMENT_NODE) {
             // stop wrapping text nodes when we hit the next output or
             // prompt element
-            if (el.nodeType === Node.ELEMENT_NODE && el.matches(".gp, .go")) {
+            if (el.nodeType === Node.ELEMENT_NODE && el.matches(".gp, .go, .gh")) {
                 break
             }
             // if the node is a text node with content, wrap it in a
@@ -82,6 +83,7 @@ const loadCopyButton = () => {
         + ".highlight-python3 .highlight,"
         + ".highlight-pycon .highlight,"
         + ".highlight-pycon3 .highlight,"
+        + ".highlight-ipython .highlight,"
         + ".highlight-default .highlight"
     )
 

--- a/sphinx_toggleprompt/_static/toggleprompt.js_t
+++ b/sphinx_toggleprompt/_static/toggleprompt.js_t
@@ -1,3 +1,6 @@
+// Copyright PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
+// File originates from the Python docs theme python_docs_theme/static/copybutton.js
+
 // ``function*`` denotes a generator in JavaScript, see
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
 function* getHideableCopyButtonElements(rootElement) {

--- a/sphinx_toggleprompt/_static/toggleprompt.js_t
+++ b/sphinx_toggleprompt/_static/toggleprompt.js_t
@@ -1,77 +1,92 @@
-// Copyright PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
-// File originates from the Python docs theme python_docs_theme/static/copybutton.js
+// ``function*`` denotes a generator in JavaScript, see
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
+function* getHideableCopyButtonElements(rootElement) {
+    // yield all elements with the "go" (Generic.Output),
+    // "gp" (Generic.Prompt), or "gt" (Generic.Traceback) CSS class
+    for (const el of rootElement.querySelectorAll('.go, .gp, .gt')) {
+        yield el
+    }
+    // tracebacks (.gt) contain bare text elements that need to be
+    // wrapped in a span to hide or show the element
+    for (let el of rootElement.querySelectorAll('.gt')) {
+        while ((el = el.nextSibling) && el.nodeType !== Node.DOCUMENT_NODE) {
+            // stop wrapping text nodes when we hit the next output or
+            // prompt element
+            if (el.nodeType === Node.ELEMENT_NODE && el.matches(".gp, .go")) {
+                break
+            }
+            // if the node is a text node with content, wrap it in a
+            // span element so that we can control visibility
+            if (el.nodeType === Node.TEXT_NODE && el.textContent.trim()) {
+                const wrapper = document.createElement("span")
+                el.after(wrapper)
+                wrapper.appendChild(el)
+                el = wrapper
+            }
+            yield el
+        }
+    }
+}
 
-$(document).ready(function() {
 
-    /* Add a [>>>] button on the top-right corner of code samples to hide
+const loadCopyButton = () => {
+    /* Add a [>>>] button in the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
-    var div = $('.highlight-python .highlight,' +
-                '.highlight-python3 .highlight,' +
-                '.highlight-pycon .highlight,' +
-                '.highlight-pycon3 .highlight,' +
-                '.highlight-ipython .highlight,' +
-                '.highlight-default .highlight');
-    var pre = div.find('pre');
+    const hide_text = "Hide the prompts and output"
+    const show_text = "Show the prompts and output"
 
-    // get the styles from the current theme
-    pre.parent().parent().css('position', 'relative');
-    var hide_text = 'Hide the prompts and output';
-    var show_text = 'Show the prompts and output';
-    var border_width = pre.css('border-top-width');
-    var border_style = pre.css('border-top-style');
-    var border_color = pre.css('border-top-color');
-    var button_styles = {
-        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '{{ toggleprompt_offset_right }}px',
-        'border-color': border_color, 'border-style': border_style,
-        'border-width': border_width, 'color': border_color, 'text-size': '75%',
-        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
-        'border-radius': '0 3px 0 0',
-        'user-select': 'none'
-    }
-
-    // create and add the button to all the code blocks that contain >>>
-    div.each(function(index) {
-        var jthis = $(this);
-        if (jthis.find('.gp').length > 0) {
-            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
-            button.css(button_styles)
-            button.attr('title', hide_text);
-            button.data('hidden', 'false');
-            jthis.prepend(button);
-        }
-        // tracebacks (.gt) contain bare text elements that need to be
-        // wrapped in a span to work with .nextUntil() (see later)
-        jthis.find('pre:has(.gt)').contents().filter(function() {
-            return ((this.nodeType == 3) && (this.data.trim().length > 0));
-        }).wrap('<span>');
-    });
-
-    // define the behavior of the button when it's clicked
-    $('.copybutton').click(function(e){
-        e.preventDefault();
-        var button = $(this);
-        if (button.data('hidden') === 'false') {
+    const button = document.createElement("span")
+    button.classList.add("copybutton")
+    button.innerText = ">>>"
+    button.title = hide_text
+    button.dataset.hidden = "false"
+    const buttonClick = event => {
+        // define the behavior of the button when it's clicked
+        event.preventDefault()
+        const buttonEl = event.currentTarget
+        const codeEl = buttonEl.nextElementSibling
+        if (buttonEl.dataset.hidden === "false") {
             // hide the code output
-            // `.go` for comments
-            // `.gp` for ">>>", "...", "In [x]:"
-            // `.gt` for tracebacks
-            // `.gh` for "Out[x]:"
-            button.parent().find('.go, .gp, .gh, .gt').hide();
-            button.next('pre').find('.gt').nextUntil('.gp, .gh, .go').css('visibility', 'hidden');
-            button.css('text-decoration', 'line-through');
-            button.attr('title', show_text);
-            button.data('hidden', 'true');
+            for (const el of getHideableCopyButtonElements(codeEl)) {
+                el.hidden = true
+            }
+            buttonEl.title = show_text
+            buttonEl.dataset.hidden = "true"
         } else {
             // show the code output
-            button.parent().find('.go, .gp, .gh, .gt').show();
-            button.next('pre').find('.gt').nextUntil('.gp, .gh, .go').css('visibility', 'visible');
-            button.css('text-decoration', 'none');
-            button.attr('title', hide_text);
-            button.data('hidden', 'false');
+            for (const el of getHideableCopyButtonElements(codeEl)) {
+                el.hidden = false
+            }
+            buttonEl.title = hide_text
+            buttonEl.dataset.hidden = "false"
         }
-    });
-    if ('{{ toggleprompt_default_hidden }}' === 'true') {
-        $('.copybutton').click();  // click once to hide
     }
-});
+
+    const highlightedElements = document.querySelectorAll(
+        ".highlight-python .highlight,"
+        + ".highlight-python3 .highlight,"
+        + ".highlight-pycon .highlight,"
+        + ".highlight-pycon3 .highlight,"
+        + ".highlight-default .highlight"
+    )
+
+    // create and add the button to all the code blocks that contain >>>
+    highlightedElements.forEach(el => {
+        el.style.position = "relative"
+
+        // if we find a console prompt (.gp), prepend the (deeply cloned) button
+        const clonedButton = button.cloneNode(true)
+        // the onclick attribute is not cloned, set it on the new element
+        clonedButton.onclick = buttonClick
+        if (el.querySelector(".gp") !== null) {
+            el.prepend(clonedButton)
+        }
+    })
+}
+
+if (document.readyState !== "loading") {
+    loadCopyButton()
+} else {
+    document.addEventListener("DOMContentLoaded", loadCopyButton)
+}

--- a/sphinx_toggleprompt/_static/toggleprompt.js_t
+++ b/sphinx_toggleprompt/_static/toggleprompt.js_t
@@ -103,6 +103,9 @@ const loadCopyButton = () => {
         clonedButton.onclick = buttonClick
         if (el.querySelector(".gp") !== null) {
             el.prepend(clonedButton)
+            if ('{{ toggleprompt_default_hidden }}' === 'true') {
+                clonedButton.click()  // click once to hide
+            }
         }
     })
 }

--- a/sphinx_toggleprompt/_static/toggleprompt.js_t
+++ b/sphinx_toggleprompt/_static/toggleprompt.js_t
@@ -44,6 +44,17 @@ const loadCopyButton = () => {
     button.innerText = ">>>"
     button.title = hide_text
     button.dataset.hidden = "false"
+    button.style.setProperty('cursor', 'pointer')
+    button.style.setProperty('position', 'absolute')
+    button.style.setProperty('top', '0')
+    button.style.setProperty('right', '{{ toggleprompt_offset_right }}px')
+    button.style.setProperty('text-size', '75%')
+    button.style.setProperty('font-family', 'monospace')
+    button.style.setProperty('padding-left', '0.2em')
+    button.style.setProperty('padding-right', '0.2em')
+    button.style.setProperty('border-radius', '0 3px 0 0')
+    button.style.setProperty('user-select', 'none')
+
     const buttonClick = event => {
         // define the behavior of the button when it's clicked
         event.preventDefault()
@@ -80,6 +91,12 @@ const loadCopyButton = () => {
 
         // if we find a console prompt (.gp), prepend the (deeply cloned) button
         const clonedButton = button.cloneNode(true)
+
+        clonedButton.style.setProperty('border-color', el.style.BorderTopColor),
+        clonedButton.style.setProperty('border-style', el.style.BorderTopStyle),
+        clonedButton.style.setProperty('border-width', el.style.BorderTopWidth),
+        clonedButton.style.setProperty('color', el.style.BorderTopColor),
+
         // the onclick attribute is not cloned, set it on the new element
         clonedButton.onclick = buttonClick
         if (el.querySelector(".gp") !== null) {


### PR DESCRIPTION
Closes #23

- Updated the main javascript code to match [that from the official Python docs theme](https://github.com/python/python-docs-theme/blob/d1e6df49a042c3aae79a2a9bc384bb1587fae777/python_docs_theme/static/copybutton.js)
  This is more or less a complete rewrite, and notably no longer relies on jquery.
- Support Sphinx 4.5.0 through 8.x (previously was 4.5.0 through 5.x).
- Support Python 3.9 through 3.12 (previously was 3.6 through 3.11).