### PR TITLE
Support Sphinx>=5.0.0 & Python 3.13

### DIFF
--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -18,6 +18,9 @@ jobs:
           "sphinx==7.2.6",
           "sphinx",
         ]
+        exclude:
+          - python-version: "3.13"
+            sphinx-ver: "sphinx==5.3.0"
 
     steps:
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -16,7 +16,8 @@ jobs:
           "sphinx==5.3.0",
           "sphinx==6.2.1",
           "sphinx==7.2.6",
-          "sphinx",
+          "sphinx==8.1.3",
+          "sphinx",  # Latest
         ]
         exclude:
           - python-version: "3.13"

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -22,6 +22,8 @@ jobs:
         exclude:
           - python-version: "3.13"
             sphinx-ver: "sphinx==5.3.0"
+          - python-version: "3.9"
+            sphinx-ver: "sphinx==8.1.3"
 
     steps:
 

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         docs-dir: ["doc", "doc_copybutton"]
         sphinx-ver: [
           "sphinx==5.3.0",

--- a/.github/workflows/test_build_docs.yml
+++ b/.github/workflows/test_build_docs.yml
@@ -12,7 +12,12 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         docs-dir: ["doc", "doc_copybutton"]
-        sphinx-ver: ["4.5.0", "5.3.0", "6.2.1", "7.2.6"]
+        sphinx-ver: [
+          "sphinx==5.3.0",
+          "sphinx==6.2.1",
+          "sphinx==7.2.6",
+          "sphinx",
+        ]
 
     steps:
 
@@ -26,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install sphinx==${{ matrix.sphinx-ver }}
+        python -m pip install ${{ matrix.sphinx-ver }}
         pip install .
         pip install -r ${{ matrix.docs-dir }}/requirements.txt
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,10 +154,12 @@ There's an example of this in the doc_copybutton folder.
 Changelog
 ================================
 
-V0.5.3 - 07-feb-2025
+V0.6.0 - 07-feb-2025
 -----------------------
 
 - Added support for Sphinx 8.x
+- CI tests with Python 3.13
+- Drop <8 sphinx version limit - now, any sphinx 5.0.0 or later is allowed.
 
 
 V0.5.2 - 07-jan-2024

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,6 +154,12 @@ There's an example of this in the doc_copybutton folder.
 Changelog
 ================================
 
+V0.5.3 - 07-feb-2025
+-----------------------
+
+- Added support for Sphinx 8.x
+
+
 V0.5.2 - 07-jan-2024
 -----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     classifiers=["License :: OSI Approved :: MIT License"],
     python_requires=">=3.9",
     install_requires=[
-        "sphinx>=4.5.0,<9",
+        "sphinx>=5.0.0",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     classifiers=["License :: OSI Approved :: MIT License"],
     python_requires=">=3.9",
     install_requires=[
-        "sphinx>=4.5.0,<8",
+        "sphinx>=4.5.0,<9",
     ]
 )

--- a/sphinx_toggleprompt/__init__.py
+++ b/sphinx_toggleprompt/__init__.py
@@ -2,7 +2,7 @@ from sphinx.util import logging
 from pathlib import Path
 
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"
 logger = logging.getLogger(__name__)
 
 

--- a/sphinx_toggleprompt/__init__.py
+++ b/sphinx_toggleprompt/__init__.py
@@ -2,7 +2,7 @@ from sphinx.util import logging
 from pathlib import Path
 
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
I have tested it with Sphinx 8.1.3. It works. Matter of fact, the extension is not likely to not working with newer versions of Sphinx; maybe even the upper version limit for Sphinx (currently v9) can be removed altogether.